### PR TITLE
[ compat ] adjust to changes in elab-util

### DIFF
--- a/src/Generics/Newtype.idr
+++ b/src/Generics/Newtype.idr
@@ -8,14 +8,14 @@ import public Generics.Newtype.FromDouble
 import public Generics.Newtype.Integral
 import public Generics.Derive
 
--- %language ElabReflection
--- 
--- public export
--- data Raf = MkRaf Double
--- %runElab derive "Raf"
---   [Generic, Eq, Ord, Num, Neg, Abs, Fractional, FromDouble]
--- 
--- public export
--- data Raff a b = MkRaff a b
--- %runElab derive "Raff"
---   [Generic, Eq, Ord, Num, Neg, Abs, Fractional, FromDouble, Integral]
+%language ElabReflection
+
+public export
+data Raf = MkRaf Double
+%runElab derive "Raf"
+  [Generic, Eq, Ord, Num, Neg, Abs, Fractional, FromDouble]
+
+public export
+data Raff a b = MkRaff a b
+%runElab derive "Raff"
+  [Generic, Eq, Ord, Num, Neg, Abs, Fractional, FromDouble, Integral]

--- a/src/Generics/Newtype/Abs.idr
+++ b/src/Generics/Newtype/Abs.idr
@@ -44,12 +44,13 @@ genericAbs = to . abs . from
 export
 ||| Derives a `Abs` implementation for the given data type
 ||| and visibility.
-AbsVis : Visibility -> DeriveUtil -> InterfaceImpl
-AbsVis vis g = MkInterfaceImpl "Abs" vis []
-                       `(MkAbs genericAbs)
-                       (implementationType `(Abs) g)
+AbsVis : Visibility -> List Name -> ParamTypeInfo -> List TopLevel
+AbsVis v _ p =
+  let nm := implName p "Abs"
+      cl := var nm .= `(MkAbs genericAbs)
+   in [TL (interfaceHint v nm (implType "Abs" p)) (def nm [cl])]
 
 export
 ||| Alias for `EncodeVis Public`.
-Abs : DeriveUtil -> InterfaceImpl
+Abs : List Name -> ParamTypeInfo -> List TopLevel
 Abs = AbsVis Public

--- a/src/Generics/Newtype/Abs.idr
+++ b/src/Generics/Newtype/Abs.idr
@@ -44,13 +44,13 @@ genericAbs = to . abs . from
 export
 ||| Derives a `Abs` implementation for the given data type
 ||| and visibility.
-AbsVis : Visibility -> List Name -> ParamTypeInfo -> List TopLevel
+AbsVis : Visibility -> List Name -> ParamTypeInfo -> Res (List TopLevel)
 AbsVis v _ p =
   let nm := implName p "Abs"
       cl := var nm .= `(MkAbs genericAbs)
-   in [TL (interfaceHint v nm (implType "Abs" p)) (def nm [cl])]
+   in Right [TL (interfaceHint v nm (implType "Abs" p)) (def nm [cl])]
 
 export
 ||| Alias for `EncodeVis Public`.
-Abs : List Name -> ParamTypeInfo -> List TopLevel
+Abs : List Name -> ParamTypeInfo -> Res (List TopLevel)
 Abs = AbsVis Public

--- a/src/Generics/Newtype/Fractional.idr
+++ b/src/Generics/Newtype/Fractional.idr
@@ -52,12 +52,13 @@ genericRecip = to . recip . from
 export
 ||| Derives a `Fractional` implementation for the given data type
 ||| and visibility.
-FractionalVis : Visibility -> DeriveUtil -> InterfaceImpl
-FractionalVis vis g = MkInterfaceImpl "Fractional" vis []
-                       `(MkFractional genericDivFractional genericRecip)
-                       (implementationType `(Fractional) g)
+FractionalVis : Visibility -> List Name -> ParamTypeInfo -> List TopLevel
+FractionalVis v _ p =
+  let nm := implName p "Fractional"
+      cl := var nm .= `(MkFractional genericDivFractional genericRecip)
+   in [TL (interfaceHint v nm (implType "Fractional" p)) (def nm [cl])]
 
 export
-||| Alias for `EncodeVis Public`.
-Fractional : DeriveUtil -> InterfaceImpl
+||| Alias for `FractionalVis Public`.
+Fractional : List Name -> ParamTypeInfo -> List TopLevel
 Fractional = FractionalVis Public

--- a/src/Generics/Newtype/Fractional.idr
+++ b/src/Generics/Newtype/Fractional.idr
@@ -52,13 +52,13 @@ genericRecip = to . recip . from
 export
 ||| Derives a `Fractional` implementation for the given data type
 ||| and visibility.
-FractionalVis : Visibility -> List Name -> ParamTypeInfo -> List TopLevel
+FractionalVis : Visibility -> List Name -> ParamTypeInfo -> Res (List TopLevel)
 FractionalVis v _ p =
   let nm := implName p "Fractional"
       cl := var nm .= `(MkFractional genericDivFractional genericRecip)
-   in [TL (interfaceHint v nm (implType "Fractional" p)) (def nm [cl])]
+   in Right [TL (interfaceHint v nm (implType "Fractional" p)) (def nm [cl])]
 
 export
 ||| Alias for `FractionalVis Public`.
-Fractional : List Name -> ParamTypeInfo -> List TopLevel
+Fractional : List Name -> ParamTypeInfo -> Res (List TopLevel)
 Fractional = FractionalVis Public

--- a/src/Generics/Newtype/FromDouble.idr
+++ b/src/Generics/Newtype/FromDouble.idr
@@ -35,12 +35,13 @@ genericFromDouble = to . fromDouble
 export
 ||| Derives a `FromDouble` implementation for the given data type
 ||| and visibility.
-FromDoubleVis : Visibility -> DeriveUtil -> InterfaceImpl
-FromDoubleVis vis g = MkInterfaceImpl "FromDouble" vis []
-                       `(MkFromDouble genericFromDouble)
-                       (implementationType `(FromDouble) g)
+FromDoubleVis : Visibility -> List Name -> ParamTypeInfo -> List TopLevel
+FromDoubleVis v _ p =
+  let nm := implName p "FromDouble"
+      cl := var nm .= `(MkFromDouble genericFromDouble)
+   in [TL (interfaceHint v nm (implType "FromDouble" p)) (def nm [cl])]
 
 export
-||| Alias for `EncodeVis Public`.
-FromDouble : DeriveUtil -> InterfaceImpl
+||| Alias for `FromDouble Public`.
+FromDouble : List Name -> ParamTypeInfo -> List TopLevel
 FromDouble = FromDoubleVis Public

--- a/src/Generics/Newtype/FromDouble.idr
+++ b/src/Generics/Newtype/FromDouble.idr
@@ -35,13 +35,13 @@ genericFromDouble = to . fromDouble
 export
 ||| Derives a `FromDouble` implementation for the given data type
 ||| and visibility.
-FromDoubleVis : Visibility -> List Name -> ParamTypeInfo -> List TopLevel
+FromDoubleVis : Visibility -> List Name -> ParamTypeInfo -> Res (List TopLevel)
 FromDoubleVis v _ p =
   let nm := implName p "FromDouble"
       cl := var nm .= `(MkFromDouble genericFromDouble)
-   in [TL (interfaceHint v nm (implType "FromDouble" p)) (def nm [cl])]
+   in Right [TL (interfaceHint v nm (implType "FromDouble" p)) (def nm [cl])]
 
 export
 ||| Alias for `FromDouble Public`.
-FromDouble : List Name -> ParamTypeInfo -> List TopLevel
+FromDouble : List Name -> ParamTypeInfo -> Res (List TopLevel)
 FromDouble = FromDoubleVis Public

--- a/src/Generics/Newtype/Integral.idr
+++ b/src/Generics/Newtype/Integral.idr
@@ -52,13 +52,13 @@ genericMod x y = to $ mod (from x) (from y)
 export
 ||| Derives a `Integral` implementation for the given data type
 ||| and visibility.
-IntegralVis : Visibility -> List Name -> ParamTypeInfo -> List TopLevel
+IntegralVis : Visibility -> List Name -> ParamTypeInfo -> Res (List TopLevel)
 IntegralVis v _ p =
   let nm := implName p "Integral"
       cl := var nm .= `(MkIntegral genericDivIntegral genericMod)
-   in [TL (interfaceHint v nm (implType "Integral" p)) (def nm [cl])]
+   in Right [TL (interfaceHint v nm (implType "Integral" p)) (def nm [cl])]
 
 export
 ||| Alias for `IntegralVis Public`.
-Integral : List Name -> ParamTypeInfo -> List TopLevel
+Integral : List Name -> ParamTypeInfo -> Res (List TopLevel)
 Integral = IntegralVis Public

--- a/src/Generics/Newtype/Integral.idr
+++ b/src/Generics/Newtype/Integral.idr
@@ -52,12 +52,13 @@ genericMod x y = to $ mod (from x) (from y)
 export
 ||| Derives a `Integral` implementation for the given data type
 ||| and visibility.
-IntegralVis : Visibility -> DeriveUtil -> InterfaceImpl
-IntegralVis vis g = MkInterfaceImpl "Integral" vis []
-                       `(MkIntegral genericDivIntegral genericMod)
-                       (implementationType `(Integral) g)
+IntegralVis : Visibility -> List Name -> ParamTypeInfo -> List TopLevel
+IntegralVis v _ p =
+  let nm := implName p "Integral"
+      cl := var nm .= `(MkIntegral genericDivIntegral genericMod)
+   in [TL (interfaceHint v nm (implType "Integral" p)) (def nm [cl])]
 
 export
-||| Alias for `EncodeVis Public`.
-Integral : DeriveUtil -> InterfaceImpl
+||| Alias for `IntegralVis Public`.
+Integral : List Name -> ParamTypeInfo -> List TopLevel
 Integral = IntegralVis Public

--- a/src/Generics/Newtype/Neg.idr
+++ b/src/Generics/Newtype/Neg.idr
@@ -52,12 +52,13 @@ genericSubtract x y = to $ (-) (from x) (from y)
 export
 ||| Derives a `Neg` implementation for the given data type
 ||| and visibility.
-NegVis : Visibility -> DeriveUtil -> InterfaceImpl
-NegVis vis g = MkInterfaceImpl "Neg" vis []
-                       `(MkNeg genericNegate genericSubtract)
-                       (implementationType `(Neg) g)
+NegVis : Visibility -> List Name -> ParamTypeInfo -> List TopLevel
+NegVis v _ p =
+  let nm := implName p "Neg"
+      cl := var nm .= `(MkNeg genericNegate genericSubtract)
+   in [TL (interfaceHint v nm (implType "Neg" p)) (def nm [cl])]
 
 export
-||| Alias for `EncodeVis Public`.
-Neg : DeriveUtil -> InterfaceImpl
+||| Alias for `NegVis Public`.
+Neg : List Name -> ParamTypeInfo -> List TopLevel
 Neg = NegVis Public

--- a/src/Generics/Newtype/Neg.idr
+++ b/src/Generics/Newtype/Neg.idr
@@ -52,13 +52,13 @@ genericSubtract x y = to $ (-) (from x) (from y)
 export
 ||| Derives a `Neg` implementation for the given data type
 ||| and visibility.
-NegVis : Visibility -> List Name -> ParamTypeInfo -> List TopLevel
+NegVis : Visibility -> List Name -> ParamTypeInfo -> Res (List TopLevel)
 NegVis v _ p =
   let nm := implName p "Neg"
       cl := var nm .= `(MkNeg genericNegate genericSubtract)
-   in [TL (interfaceHint v nm (implType "Neg" p)) (def nm [cl])]
+   in Right [TL (interfaceHint v nm (implType "Neg" p)) (def nm [cl])]
 
 export
 ||| Alias for `NegVis Public`.
-Neg : List Name -> ParamTypeInfo -> List TopLevel
+Neg : List Name -> ParamTypeInfo -> Res (List TopLevel)
 Neg = NegVis Public

--- a/src/Generics/Newtype/Num.idr
+++ b/src/Generics/Newtype/Num.idr
@@ -52,12 +52,13 @@ genericFromInteger = to . fromInteger
 export
 ||| Derives a `Num` implementation for the given data type
 ||| and visibility.
-NumVis : Visibility -> DeriveUtil -> InterfaceImpl
-NumVis vis g = MkInterfaceImpl "Num" vis []
-                       `(MkNum genericPlus genericMult genericFromInteger)
-                       (implementationType `(Num) g)
+NumVis : Visibility -> List Name -> ParamTypeInfo -> List TopLevel
+NumVis v _ p =
+  let nm := implName p "Num"
+      cl := var nm .= `(MkNum genericPlus genericMult genericFromInteger)
+   in [TL (interfaceHint v nm (implType "Num" p)) (def nm [cl])]
 
 export
-||| Alias for `EncodeVis Public`.
-Num : DeriveUtil -> InterfaceImpl
+||| Alias for `NumVis Public`.
+Num : List Name -> ParamTypeInfo -> List TopLevel
 Num = NumVis Public

--- a/src/Generics/Newtype/Num.idr
+++ b/src/Generics/Newtype/Num.idr
@@ -52,13 +52,13 @@ genericFromInteger = to . fromInteger
 export
 ||| Derives a `Num` implementation for the given data type
 ||| and visibility.
-NumVis : Visibility -> List Name -> ParamTypeInfo -> List TopLevel
+NumVis : Visibility -> List Name -> ParamTypeInfo -> Res (List TopLevel)
 NumVis v _ p =
   let nm := implName p "Num"
       cl := var nm .= `(MkNum genericPlus genericMult genericFromInteger)
-   in [TL (interfaceHint v nm (implType "Num" p)) (def nm [cl])]
+   in Right [TL (interfaceHint v nm (implType "Num" p)) (def nm [cl])]
 
 export
 ||| Alias for `NumVis Public`.
-Num : List Name -> ParamTypeInfo -> List TopLevel
+Num : List Name -> ParamTypeInfo -> Res (List TopLevel)
 Num = NumVis Public


### PR DESCRIPTION
As I wrote on discord, I'm in the process of refactoring elab-util. Those changes will break this library, and this PR fixes that. Please note, that elab-util now supports deriving of numeric types directly without the need to go via sums of products. That's less elegant, but it produces optimal code most of the time.

Anyway, I'm still busy fixing those libraries in the pack collection, which will break with the elab-util update, so please don't merge this yet. I'll drop you a note, once I merged elab-util.